### PR TITLE
Generate GIR (and VAPI)

### DIFF
--- a/libportal/account.c
+++ b/libportal/account.c
@@ -205,7 +205,7 @@ get_user_information (AccountCall *call)
  * xdp_portal_get_user_information:
  * @portal: a #XdpPortal
  * @parent: (nullable): parent window information
- * @reason: (nullable) a string that can be shown in the dialog to explain
+ * @reason: (nullable): a string that can be shown in the dialog to explain
  *    why the information is needed
  * @cancellable: (nullable): optional #GCancellable
  * @callback: (scope async): a callback to call when the request is done

--- a/libportal/docs.c
+++ b/libportal/docs.c
@@ -18,7 +18,7 @@
  */
 
 /**
- * xdp_parent_new_gtk:
+ * xdp_parent_new_gtk: (skip):
  * @window: a #GtkWindow
  *
  * Creates a XdpParent for a GtkWindow.
@@ -27,7 +27,16 @@
  */
 
 /**
- * xdp_parent_free:
+ * xdp_parent_new_from_gtk: (rename-to xdp_parent_new_gtk):
+ * @window: a #GtkWindow
+ *
+ * Creates a XdpParent for a GtkWindow.
+ *
+ * Returns: a newly created #XdpParent. Free with xdp_parent_free()
+ */
+
+/**
+ * xdp_parent_free: (skip):
  * @parent: a #XdpParent
  *
  * Frees an #XdpParent when it is no longer needed.

--- a/libportal/meson.build
+++ b/libportal/meson.build
@@ -35,6 +35,7 @@ src = [
 	'notification.c',
 	'openuri.c',
 	'portal.c',
+        'portal-gtk.c',
         'print.c',
         'remote.c',
 	'screenshot.c',
@@ -48,6 +49,7 @@ src = [
 
 gio_dep = dependency('gio-2.0')
 gio_unix_dep = dependency('gio-unix-2.0')
+gtk_dep = dependency('gtk+-3.0')
 
 install_headers(headers, subdir: 'libportal')
 
@@ -58,9 +60,43 @@ libportal = library('portal',
                     include_directories: [top_inc, libportal_inc],
                     c_args: visibility_args,
                     install: true,
-                    dependencies: [gio_dep, gio_unix_dep])
+                    dependencies: [gio_dep, gio_unix_dep, gtk_dep])
 
 libportal_dep = declare_dependency(sources: src,
                                    include_directories: top_inc,
                                    dependencies: [gio_dep, gio_unix_dep],
                                    link_with: libportal)
+
+if get_option('gir')
+  libportal_gir = gnome.generate_gir(
+      libportal,
+      sources: src + headers + ['docs.c'],
+      header: 'portal-gtk.h',
+      nsversion: '1.0',
+      namespace: 'Xdp',
+      symbol_prefix: 'xdp',
+      identifier_prefix: 'Xdp',
+      includes: [
+          'GObject-2.0',
+          'Gio-2.0',
+          'Gtk-3.0',
+      ],
+      dependencies: [libportal_dep],
+      install: true,
+      build_by_default: true,
+  )
+  if get_option('vapi')
+    libportal_vala_dep = gnome.generate_vapi('libportal',
+                                             sources: libportal_gir[0],
+                                             packages: [
+                                                 'gio-2.0',
+                                                 'gtk+-3.0',
+                                             ],
+                                             install: true,
+    )
+  endif
+else
+  if get_option('vapi')
+    error('Can\'t generate VAPI without GIR')
+  endif
+endif

--- a/libportal/portal-enums.c.template
+++ b/libportal/portal-enums.c.template
@@ -1,5 +1,6 @@
 /*** BEGIN file-header ***/
 
+#include "config.h"
 #include "portal.h"
 
 /*** END file-header ***/

--- a/libportal/portal-gtk.c
+++ b/libportal/portal-gtk.c
@@ -16,28 +16,11 @@
  */
 
 #include "config.h"
+#include "portal-gtk.h"
 
-#include "utils-private.h"
-
-G_DEFINE_BOXED_TYPE (XdpParent, xdp_parent, _xdp_parent_copy, _xdp_parent_free)
 
 XdpParent *
-_xdp_parent_copy (XdpParent *source)
+xdp_parent_new_from_gtk (GtkWindow *window)
 {
-  XdpParent *parent;
-
-  parent = g_new0 (XdpParent, 1);
-
-  parent->export = source->export;
-  parent->unexport = source->unexport;
-  g_set_object (&parent->object, source->object);
-
-  return parent;
-}
-
-void
-_xdp_parent_free (XdpParent *parent)
-{
-  g_clear_object (&parent->object);
-  g_free (parent);
+  return xdp_parent_new_gtk (window);
 }

--- a/libportal/portal-gtk.h
+++ b/libportal/portal-gtk.h
@@ -33,16 +33,22 @@ static inline void _xdp_parent_exported_wayland (GdkWindow *window,
                                                  const char *handle,
                                                  gpointer data)
 
+#ifndef __GI_SCANNER__
 {
   XdpParent *parent = data;
   g_autofree char *handle_str = g_strdup_printf ("wayland:%s", handle);
   parent->callback (parent, handle_str, parent->data);
 }
+#else
+;
+#endif
 
 static inline gboolean _xdp_parent_export_gtk (XdpParent *parent,
                                                XdpParentExported callback,
                                                gpointer data)
+#ifndef __GI_SCANNER__
 {
+  
 #ifdef GDK_WINDOWING_X11
   if (GDK_IS_X11_DISPLAY (gtk_widget_get_display (GTK_WIDGET (parent->object))))
     {
@@ -65,6 +71,9 @@ static inline gboolean _xdp_parent_export_gtk (XdpParent *parent,
   g_warning ("Couldn't export handle, unsupported windowing system");
   return FALSE;
 }
+#else
+;
+#endif
 
 static inline void _xdp_parent_unexport_gtk (XdpParent *parent)
 {
@@ -82,9 +91,12 @@ void       xdp_parent_free    (XdpParent *parent);
 XdpParent *xdp_parent_new_gtk (GtkWindow *window);
 #endif
 
-static inline XdpParent *xdp_parent_new_gtk (GtkWindow *window);
+XDP_PUBLIC
+XdpParent               *xdp_parent_new_from_gtk (GtkWindow *window);
 
-static inline XdpParent *xdp_parent_new_gtk (GtkWindow *window)
+static inline XdpParent *xdp_parent_new_gtk      (GtkWindow *window);
+
+static inline XdpParent *xdp_parent_new_gtk      (GtkWindow *window)
 {
   XdpParent *parent = g_new0 (XdpParent, 1);
   parent->export = _xdp_parent_export_gtk;

--- a/libportal/portal-helpers.h
+++ b/libportal/portal-helpers.h
@@ -29,8 +29,10 @@ G_DECLARE_FINAL_TYPE (XdpPortal, xdp_portal, XDP, PORTAL, GObject)
 #define XDP_PUBLIC extern
 #endif
 
+#ifndef __GI_SCANNER__
 XDP_PUBLIC
 GType      xdp_portal_get_type               (void) G_GNUC_CONST;
+#endif
 
 XDP_PUBLIC
 XdpPortal *xdp_portal_new                    (void);
@@ -61,9 +63,12 @@ struct _XdpParent {
   gpointer data;
 };
 
-static inline void xdp_parent_free (XdpParent *parent);
+XDP_PUBLIC
+GType              xdp_parent_get_type (void) G_GNUC_CONST;
 
-static inline void xdp_parent_free (XdpParent *parent)
+static inline void xdp_parent_free     (XdpParent *parent);
+
+static inline void xdp_parent_free     (XdpParent *parent)
 {
   g_clear_object (&parent->data);
   g_free (parent);

--- a/libportal/remote.h
+++ b/libportal/remote.h
@@ -25,8 +25,10 @@ G_BEGIN_DECLS
 
 G_DECLARE_FINAL_TYPE (XdpSession, xdp_session, XDP, SESSION, GObject)
 
+#ifndef __GI_SCANNER__
 XDP_PUBLIC
 GType xdp_session_get_type (void) G_GNUC_CONST;
+#endif
 
 /**
  * XdpOutputType:

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,9 @@
+option('gir',
+       type: 'boolean',
+       value: true,
+       description: 'Generate GIR')
+
+option('vapi',
+       type: 'boolean',
+       value: true,
+       description: 'Generate VAPI')

--- a/portal-test/meson.build
+++ b/portal-test/meson.build
@@ -1,5 +1,4 @@
 
-gtk_dep = dependency('gtk+-3.0')
 gst_dep = dependency('gstreamer-audio-1.0')
 
 resources = gnome.compile_resources('resources',


### PR DESCRIPTION
Moves the gtk dep to the lib itself so that Xdp.Parent.new_gtk() is actually callable from bindings

Not great but works